### PR TITLE
Correct code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ authenticate using the `Client` class:
 
 ```php
 <?php
+use Transmission\Client;
 use Transmission\Transmission;
 
+$client = new Client();
+$client->authenticate('username', 'password');
 $transmission = new Transmission();
-$transmission->authenticate('username', 'password');
+$transmission->setClient($client);
 ```
 
 Additionally, you can control the actual Transmission setting. This means


### PR DESCRIPTION
The code example for connecting to Transmission with a username and password seems to be incorrect. I had to dig through the source code to see how to properly implement it. This should fix it to provide everyone with the correct usage.
