### PR TITLE
Add $savepath argument to $transmission->add() function

### DIFF
--- a/lib/Transmission/Transmission.php
+++ b/lib/Transmission/Transmission.php
@@ -156,13 +156,16 @@ class Transmission
      */
     public function add($torrent, $metainfo = false, $savepath = null)
     {
-       $parameters = array($metainfo ? 'metainfo' : 'filename' => $torrent);
-			
-		if ($savepath !== null) {
-				$parameters['download-dir'] = (string) $savepath;
-			}
+	$parameters = array($metainfo ? 'metainfo' : 'filename' => $torrent);
 
-			$response = $this->getClient()->call('torrent-add', $parameters);
+	if ($savepath !== null) {
+		$parameters['download-dir'] = (string) $savepath;
+	}
+
+	$response = $this->getClient()->call(
+		'torrent-add',
+		$parameters
+	);
 
         return $this->getMapper()->map(
             new Torrent($this->getClient()),


### PR DESCRIPTION
If $savepath argument is specified, the torrent will be downloaded to the value of $savepath
