### PR TITLE
Add getUploadRatio() function to retrieve share ratio on current object

### DIFF
--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -74,6 +74,11 @@ class Torrent extends AbstractModel
     protected $trackers = array();
 
     /**
+     * @var double
+     */
+    protected $uploadRatio;
+
+    /**
      * @param integer $id
      */
     public function setId($id)
@@ -288,6 +293,22 @@ class Torrent extends AbstractModel
     }
 
     /**
+     * @param double $ratio
+     */
+    public function setUploadRatio($ratio)
+    {
+        $this->uploadRatio = (double) $ratio;
+    }
+
+    /**
+     * @return double
+     */
+    public function getUploadRatio()
+    {
+        return $this->uploadRatio;
+    }
+
+    /**
      * @return boolean
      */
     public function isStopped()
@@ -337,6 +358,7 @@ class Torrent extends AbstractModel
             'files' => 'files',
             'peers' => 'peers',
             'trackers' => 'trackers',
+            'uploadRatio' => 'uploadRatio',
             'hashString' => 'hash'
         );
     }


### PR DESCRIPTION
Usage example:

// Getting a specific torrent from the download queue
$torrent = $transmission->get(1);

// Getting share ratio of the selected torrent
$torrent->getUploadRatio();  // Will return 0.5033 for example; If the return value is 1, it will say that the torrent is seeded 1 time
