### PR TITLE
Add property $torrent->getSecondsSeeding()

### DIFF
--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -61,6 +61,11 @@ class Torrent extends AbstractModel
     /**
      * @var integer
      */
+    protected $secondsSeeding;
+
+    /**
+     * @var integer
+     */
     protected $peersConnected;
 
     /**
@@ -243,6 +248,22 @@ class Torrent extends AbstractModel
     {
         $this->downloadRate = (integer) $rate;
     }
+
+    /**
+     * @param integer $seconds
+     */
+    public function setSecondsSeeding($seconds)
+    {
+        $this->secondsSeeding = $seconds;
+    }
+
+    /**
+     * @return integer $secondsSeeding
+     */
+    public function getSecondsSeeding()
+    {
+        return $this->secondsSeeding;
+    }
 	
 	/**
      * @param integer $peersConnected
@@ -417,6 +438,7 @@ class Torrent extends AbstractModel
             'isFinished' => 'finished',
             'rateUpload' => 'uploadRate',
             'rateDownload' => 'downloadRate',
+            'secondsSeeding' => 'secondsSeeding',
             'percentDone' => 'percentDone',
             'files' => 'files',
             'peers' => 'peers',

--- a/tests/Transmission/Tests/Model/TorrentTest.php
+++ b/tests/Transmission/Tests/Model/TorrentTest.php
@@ -40,6 +40,7 @@ class TorrentTest extends \PHPUnit_Framework_TestCase
             'isFinished' => false,
             'rateUpload' => 10,
             'rateDownload' => 100,
+            'secondsSeeding' => 30,
             'files' => array(
                 (object) array()
             ),
@@ -72,6 +73,7 @@ class TorrentTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->getTorrent()->isFinished());
         $this->assertEquals(10, $this->getTorrent()->getUploadRate());
         $this->assertEquals(100, $this->getTorrent()->getDownloadRate());
+        $this->assertEquals(30, $this->getTorrent()->getSecondsSeeding());
         $this->assertCount(1, $this->getTorrent()->getFiles());
         $this->assertCount(2, $this->getTorrent()->getPeers());
         $this->assertCount(3, $this->getTorrent()->getTrackers());


### PR DESCRIPTION
This property can be useful if you want to delete, move or otherwise change a torrent after a certain period of time.

A test has been included.
