### PR TITLE
Add downloadedEver and uploadedEver stats to Transmission\Model\Torrent

### DIFF
--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -99,6 +99,16 @@ class Torrent extends AbstractModel
     protected $downloadDir;
 
     /**
+     * @var integer
+     */
+    protected $downloadedEver;
+
+    /**
+     * @var integer
+     */
+    protected $uploadedEver;
+
+    /**
      * @param integer $id
      */
     public function setId($id)
@@ -425,6 +435,34 @@ class Torrent extends AbstractModel
     }
 
     /**
+     * @return int
+     */
+    public function getDownloadedEver() {
+        return $this->downloadedEver;
+    }
+
+    /**
+     * @param int $downloadedEver
+     */
+    public function setDownloadedEver($downloadedEver) {
+        $this->downloadedEver = $downloadedEver;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUploadedEver() {
+        return $this->uploadedEver;
+    }
+
+    /**
+     * @param int $uploadedEver
+     */
+    public function setUploadedEver($uploadedEver) {
+        $this->uploadedEver = $uploadedEver;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public static function getMapping()
@@ -447,7 +485,9 @@ class Torrent extends AbstractModel
             'startDate' => 'startDate',
             'uploadRatio' => 'uploadRatio',
             'hashString' => 'hash',
-            'downloadDir' => 'downloadDir'
+            'downloadDir' => 'downloadDir',
+            'downloadedEver' => 'downloadedEver',
+            'uploadedEver' => 'uploadedEver'
         );
     }
 }

--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -94,9 +94,9 @@ class Torrent extends AbstractModel
     protected $uploadRatio;
     
     /**
-	 * @var string
-	 */
-	protected $downloadDir;
+     * @var string
+     */
+    protected $downloadDir;
 
     /**
      * @param integer $id
@@ -248,8 +248,8 @@ class Torrent extends AbstractModel
     {
         $this->downloadRate = (integer) $rate;
     }
-	
-	/**
+
+    /**
      * @param integer $peersConnected
      */
     public function setPeersConnected($peersConnected)
@@ -409,20 +409,20 @@ class Torrent extends AbstractModel
     }
     
     /**
-	 * @return string
-	 */
-	public function getDownloadDir()
-	{
-		return $this->downloadDir;
-	}
+     * @return string
+     */
+    public function getDownloadDir()
+    {
+        return $this->downloadDir;
+    }
 
-	/**
-	 * @param string $downloadDir
-	 */
-	public function setDownloadDir($downloadDir)
-	{
-		$this->downloadDir = $downloadDir;
-	}
+    /**
+     * @param string $downloadDir
+     */
+    public function setDownloadDir($downloadDir)
+    {
+        $this->downloadDir = $downloadDir;
+    }
 
     /**
      * {@inheritDoc}

--- a/tests/Transmission/Tests/Model/TorrentTest.php
+++ b/tests/Transmission/Tests/Model/TorrentTest.php
@@ -41,6 +41,8 @@ class TorrentTest extends \PHPUnit_Framework_TestCase
             'rateUpload' => 10,
             'rateDownload' => 100,
             'downloadDir' => '/home/foo',
+            'downloadedEver' => 1024000000,
+            'uploadedEver' => 1024000000000, // 1 Tb
             'files' => array(
                 (object) array()
             ),
@@ -74,6 +76,8 @@ class TorrentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $this->getTorrent()->getUploadRate());
         $this->assertEquals(100, $this->getTorrent()->getDownloadRate());
         $this->assertEquals('/home/foo', $this->getTorrent()->getDownloadDir());
+        $this->assertEquals(1024000000, $this->getTorrent()->getDownloadedEver());
+        $this->assertEquals(1024000000000, $this->getTorrent()->getUploadedEver());
         $this->assertCount(1, $this->getTorrent()->getFiles());
         $this->assertCount(2, $this->getTorrent()->getPeers());
         $this->assertCount(3, $this->getTorrent()->getTrackers());

--- a/tests/Transmission/Tests/Model/TorrentTest.php
+++ b/tests/Transmission/Tests/Model/TorrentTest.php
@@ -106,7 +106,7 @@ class TorrentTest extends \PHPUnit_Framework_TestCase
     public function shouldHaveConvenienceMethods($status, $method)
     {
         $methods = array('stopped', 'checking', 'downloading', 'seeding');
-        $accessor = PropertyAccess::getPropertyAccessor();
+        $accessor = PropertyAccess::createPropertyAccessor();
         $this->getTorrent()->setStatus($status);
 
         $methods = array_filter($methods, function ($value) use ($method) {


### PR DESCRIPTION
Hello, I'm going to send stats from Transmisison to InfluxDB for detect unpopular torrents, I need metric "Uploaded" for that and add it to your library. I've tested it though unit tests and on real Transmission 2.84 (14306).

And, while unit testing, I got fatal error because PropertyAccess 2.3+ changed methods (see commit message).