### PR TITLE
PHPDOC fixes

### DIFF
--- a/lib/Transmission/Client.php
+++ b/lib/Transmission/Client.php
@@ -54,7 +54,7 @@ class Client
     protected $token;
 
     /**
-     * @var Buzz\Client\ClientInterface
+     * @var ClientInterface
      */
     protected $client;
 
@@ -96,8 +96,8 @@ class Client
      *
      * @param  string           $method
      * @param  array            $arguments
-     * @return stdClass
-     * @throws RuntimeException
+     * @return \stdClass
+     * @throws \RuntimeException
      */
     public function call($method, array $arguments)
     {
@@ -211,7 +211,7 @@ class Client
     /**
      * Set the Buzz client used to connect to Transmission
      *
-     * @param Buzz\Client\ClientInterface $client
+     * @param ClientInterface $client
      */
     public function setClient(ClientInterface $client)
     {
@@ -221,7 +221,7 @@ class Client
     /**
      * Get the Buzz client used to connect to Transmission
      *
-     * @return Buzz\Client\ClientInterface
+     * @return ClientInterface
      */
     public function getClient()
     {
@@ -230,9 +230,8 @@ class Client
 
     /**
      * @param string $method
-     * @param array  $arguments
-     *
-     * @return <Buzz\Message\Request, Buzz\Message\Response>
+     * @param array $arguments
+     * @return array|Request[]|Response[]
      */
     protected function compose($method, $arguments)
     {
@@ -251,11 +250,11 @@ class Client
     }
 
     /**
-     * @param  Buzz\Message\Response $response
+     * @param  Response $response
      * @param  string                $method
      * @param  array                 $arguments
-     * @return stdClass
-     * @throws RuntimeException
+     * @return \stdClass
+     * @throws \RuntimeException
      */
     protected function validateResponse($response, $method, $arguments)
     {

--- a/lib/Transmission/Model/AbstractModel.php
+++ b/lib/Transmission/Model/AbstractModel.php
@@ -12,14 +12,14 @@ use Transmission\Util\ResponseValidator;
 abstract class AbstractModel implements ModelInterface
 {
     /**
-     * @var Transmission\Client
+     * @var Client
      */
     protected $client;
 
     /**
      * Constructor
      *
-     * @param Transmission\Client $client
+     * @param Client $client
      */
     public function __construct(Client $client = null)
     {
@@ -27,7 +27,7 @@ abstract class AbstractModel implements ModelInterface
     }
 
     /**
-     * @param Transmission\Client $client
+     * @param Client $client
      */
     public function setClient(Client $client)
     {
@@ -35,7 +35,7 @@ abstract class AbstractModel implements ModelInterface
     }
 
     /**
-     * @return Transmission\Client
+     * @return Client
      */
     public function getClient()
     {

--- a/lib/Transmission/Model/Status.php
+++ b/lib/Transmission/Model/Status.php
@@ -47,7 +47,7 @@ class Status extends AbstractModel
     protected $status;
 
     /**
-     * @param integer|Transmission\Model\Status $status
+     * @param integer|Status $status
      */
     public function __construct($status)
     {

--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -34,7 +34,7 @@ class Torrent extends AbstractModel
     protected $hash;
 
     /**
-     * @var integer
+     * @var Status
      */
     protected $status;
 
@@ -189,7 +189,7 @@ class Torrent extends AbstractModel
     }
 
     /**
-     * @param integer|Transmission\Model\Status $status
+     * @param integer|Status $status
      */
     public function setStatus($status)
     {

--- a/lib/Transmission/Transmission.php
+++ b/lib/Transmission/Transmission.php
@@ -45,7 +45,7 @@ class Transmission
     /**
      * Get all the torrents in the download queue
      *
-     * @return array
+     * @return Torrent[]
      */
     public function all()
     {

--- a/lib/Transmission/Transmission.php
+++ b/lib/Transmission/Transmission.php
@@ -14,17 +14,17 @@ use Transmission\Util\ResponseValidator;
 class Transmission
 {
     /**
-     * @var Transmission\Client
+     * @var Client
      */
     protected $client;
 
     /**
-     * @var Transmission\Util\ResponseValidator
+     * @var ResponseValidator
      */
     protected $validator;
 
     /**
-     * @var Transmission\Util\PropertyMapper
+     * @var PropertyMapper
      */
     protected $mapper;
 
@@ -70,8 +70,8 @@ class Transmission
      * Get a specific torrent from the download queue
      *
      * @param  integer                    $id
-     * @return Transmission\Model\Torrent
-     * @throws RuntimeException
+     * @return Torrent
+     * @throws \RuntimeException
      */
     public function get($id)
     {
@@ -98,7 +98,7 @@ class Transmission
     /**
      * Get the Transmission session
      *
-     * @return Transmission\Model\Session
+     * @return Session
      */
     public function getSession()
     {
@@ -113,6 +113,9 @@ class Transmission
         );
     }
 
+    /**
+     * @return SessionStats
+     */
     public function getSessionStats()
     {
         $response = $this->getClient()->call(
@@ -128,8 +131,8 @@ class Transmission
 
     /**
      * Get Free space
-     * @param  string                       $path
-     * @return Transmission\Model\FreeSpace
+     * @param  string $path
+     * @return FreeSpace
      */
     public function getFreeSpace($path=null)
     {
@@ -150,10 +153,10 @@ class Transmission
     /**
      * Add a torrent to the download queue
      *
-     * @param  string                     $filename
-     * @param  boolean                    $metainfo
-     * @param  string                     $savepath
-     * @return Transmission\Model\Torrent
+     * @param  string   $torrent
+     * @param  boolean  $metainfo
+     * @param  string   $savepath
+     * @return Torrent
      */
     public function add($torrent, $metainfo = false, $savepath = null)
     {
@@ -177,8 +180,8 @@ class Transmission
     /**
      * Start the download of a torrent
      *
-     * @param Transmission\Model\Torrent $torrent
-     * @param Booleam                    $now
+     * @param Torrent $torrent
+     * @param bool    $now
      */
     public function start(Torrent $torrent, $now = false)
     {
@@ -191,7 +194,7 @@ class Transmission
     /**
      * Stop the download of a torrent
      *
-     * @param Transmission\Model\Torrent $torrent
+     * @param Torrent $torrent
      */
     public function stop(Torrent $torrent)
     {
@@ -204,7 +207,7 @@ class Transmission
     /**
      * Verify the download of a torrent
      *
-     * @param Transmission\Model\Torrent $torrent
+     * @param Torrent $torrent
      */
     public function verify(Torrent $torrent)
     {
@@ -217,7 +220,7 @@ class Transmission
     /**
      * Request a reannounce of a torrent
      *
-     * @param Transmission\Model\Torrent $torrent
+     * @param Torrent $torrent
      */
     public function reannounce(Torrent $torrent)
     {
@@ -230,7 +233,7 @@ class Transmission
     /**
      * Remove a torrent from the download queue
      *
-     * @param Transmission\Model\Torrent $torrent
+     * @param Torrent $torrent
      */
     public function remove(Torrent $torrent, $localData = false)
     {
@@ -246,7 +249,7 @@ class Transmission
     /**
      * Set the client used to connect to Transmission
      *
-     * @param Transmission\Client $client
+     * @param Client $client
      */
     public function setClient(Client $client)
     {
@@ -256,7 +259,7 @@ class Transmission
     /**
      * Get the client used to connect to Transmission
      *
-     * @return Transmission\Client
+     * @return Client
      */
     public function getClient()
     {
@@ -270,7 +273,7 @@ class Transmission
      */
     public function setHost($host)
     {
-        return $this->getClient()->setHost($host);
+        $this->getClient()->setHost($host);
     }
 
     /**
@@ -290,7 +293,7 @@ class Transmission
      */
     public function setPort($port)
     {
-        return $this->getClient()->setPort($port);
+        $this->getClient()->setPort($port);
     }
 
     /**
@@ -306,7 +309,7 @@ class Transmission
     /**
      * Set the mapper used to map responses from Transmission to models
      *
-     * @param Transmission\Util\PropertyMapper $mapper
+     * @param PropertyMapper $mapper
      */
     public function setMapper(PropertyMapper $mapper)
     {
@@ -316,7 +319,7 @@ class Transmission
     /**
      * Get the mapper used to map responses from Transmission to models
      *
-     * @return Transmission\Util\PropertyMapper
+     * @return PropertyMapper
      */
     public function getMapper()
     {
@@ -326,7 +329,7 @@ class Transmission
     /**
      * Set the validator used to validate Transmission responses
      *
-     * @param Transmission\Util\ResponseValidator $validator
+     * @param ResponseValidator $validator
      */
     public function setValidator(ResponseValidator $validator)
     {
@@ -336,7 +339,7 @@ class Transmission
     /**
      * Get the validator used to validate Transmission responses
      *
-     * @return Transmission\Util\ResponseValidator
+     * @return ResponseValidator
      */
     public function getValidator()
     {

--- a/lib/Transmission/Util/PropertyMapper.php
+++ b/lib/Transmission/Util/PropertyMapper.php
@@ -12,9 +12,9 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 class PropertyMapper
 {
     /**
-     * @param  Transmission\Model\ModelInterface $model
-     * @param  stdClass                          $dto
-     * @return Transmission\Model\ModelInterface
+     * @param  ModelInterface $model
+     * @param  \stdClass                          $dto
+     * @return ModelInterface
      */
     public static function map(ModelInterface $model, $dto)
     {

--- a/lib/Transmission/Util/ResponseValidator.php
+++ b/lib/Transmission/Util/ResponseValidator.php
@@ -7,9 +7,9 @@ namespace Transmission\Util;
 class ResponseValidator
 {
     /**
-     * @param  string           $method
-     * @param  stdClass         $response
-     * @throws RuntimeException
+     * @param  string    $method
+     * @param  \stdClass $response
+     * @return \stdClass
      */
     public static function validate($method, \stdClass $response)
     {
@@ -38,8 +38,8 @@ class ResponseValidator
     }
 
     /**
-     * @param  stdClass         $response
-     * @throws RuntimeException
+     * @param  \stdClass         $response
+     * @throws \RuntimeException
      */
     public static function validateGetResponse(\stdClass $response)
     {
@@ -54,8 +54,8 @@ class ResponseValidator
     }
 
     /**
-     * @param  stdClass         $response
-     * @throws RuntimeException
+     * @param  \stdClass         $response
+     * @throws \RuntimeException
      */
     public static function validateAddResponse(\stdClass $response)
     {
@@ -84,8 +84,8 @@ class ResponseValidator
     }
 
     /**
-     * @param  stdClass $response
-     * @return stdClass
+     * @param  \stdClass $response
+     * @return \stdClass
      */
     public static function validateSessionStatsGetResponse(\stdClass $response)
     {


### PR DESCRIPTION
Hey, thanks for your work on this library first of all, I recently found a nice use for it. 

I'm dropping by with a patch to clean up PHPDOC annotations, my IDE noticed places where the namespacing wouldn't resolve without the first back-slash, or more simply, just the class name instead. I went with the class name, since most were already imported with `use`. 