### PR TITLE
Remove multiple torrents at once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,8 @@
         "psr-0": {
             "Transmission": "lib/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
     }
 }

--- a/lib/Transmission/Transmission.php
+++ b/lib/Transmission/Transmission.php
@@ -233,11 +233,24 @@ class Transmission
     /**
      * Remove a torrent from the download queue
      *
-     * @param Torrent $torrent
+     * @param array[Torrent]|Torrent $torrent
+     * @throws \RuntimeException
      */
-    public function remove(Torrent $torrent, $localData = false)
+    public function remove($torrent, $localData = false)
     {
-        $arguments = array('ids' => array($torrent->getId()));
+        if (is_array($torrent)) {
+            $torrent = array_map(function (Torrent $item) {
+                return $item->getId();
+            }, $torrent);
+
+            $arguments = array('ids' => $torrent);
+        } else {
+            if (! $torrent instanceof Torrent) {
+                throw new \RuntimeException("Torrent parameter must be instance of Torrent");
+            }
+
+            $arguments = array('ids' => array($torrent->getId()));
+        }
 
         if ($localData) {
             $arguments['delete-local-data'] = true;

--- a/tests/Transmission/Tests/ClientTest.php
+++ b/tests/Transmission/Tests/ClientTest.php
@@ -53,7 +53,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function shouldMakeApiCall()
     {
         $test   = $this;
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->once())
             ->method('send')
             ->with(
@@ -87,7 +87,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function shouldAuthenticate()
     {
         $test   = $this;
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->once())
             ->method('send')
             ->with(
@@ -123,7 +123,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldThrowExceptionOnExceptionDuringApiCall()
     {
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->once())
             ->method('send')
             ->will($this->throwException(new \Exception()));
@@ -138,7 +138,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldThrowExceptionOnUnexpectedStatusCode()
     {
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->once())
             ->method('send')
             ->will($this->returnCallback(function ($request, $response) {
@@ -155,7 +155,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldThrowExceptionOnAccessDenied()
     {
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->once())
             ->method('send')
             ->will($this->returnCallback(function ($request, $response) {
@@ -172,7 +172,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function shouldHandle409ResponseWhenMakingAnApiCall()
     {
         $test   = $this;
-        $client = $this->getMock('Buzz\Client\Curl');
+        $client = $this->createMock('Buzz\Client\Curl');
         $client->expects($this->at(0))
             ->method('send')
             ->will($this->returnCallback(function ($request, $response) use ($test) {

--- a/tests/Transmission/Tests/Model/AbstractModelTest.php
+++ b/tests/Transmission/Tests/Model/AbstractModelTest.php
@@ -34,7 +34,7 @@ class AbstractModelTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldHaveClientIfSetByUser()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
 
         $this->getModel()->setClient($client);
         $this->assertEquals($client, $this->getModel()->getClient());

--- a/tests/Transmission/Tests/Model/SessionTest.php
+++ b/tests/Transmission/Tests/Model/SessionTest.php
@@ -98,7 +98,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         PropertyMapper::map($this->getSession(), (object) $expected);
 
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('session-set', $expected)

--- a/tests/Transmission/Tests/TransmissionTest.php
+++ b/tests/Transmission/Tests/TransmissionTest.php
@@ -21,7 +21,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldGetAllTorrentsInDownloadQueue()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-get')
@@ -51,7 +51,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldGetTorrentById()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-get')
@@ -81,7 +81,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldThrowExceptionWhenTorrentIsNotFound()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-get')
@@ -104,7 +104,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldAddTorrentByFilename()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-add')
@@ -131,7 +131,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldAddTorrentByMetainfo()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-add')
@@ -158,7 +158,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldHandleDuplicateTorrent()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-add')
@@ -185,7 +185,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldGetSession()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('session-get')
@@ -210,7 +210,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldGetSessionStats()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('session-stats')
@@ -235,7 +235,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     public function shouldGetFreeSpace()
     {
         $that   = $this;
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('free-space')
@@ -258,7 +258,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldStartDownload()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-start', array('ids' => array(1)))
@@ -281,7 +281,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldStartDownloadImmediately()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-start-now', array('ids' => array(1)))
@@ -304,7 +304,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldStopDownload()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-stop', array('ids' => array(1)))
@@ -327,7 +327,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldVerifyDownload()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-verify', array('ids' => array(1)))
@@ -350,7 +350,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldReannounceDownload()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-reannounce', array('ids' => array(1)))
@@ -373,7 +373,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldRemoveDownloadWithoutRemovingLocalData()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-remove', array('ids' => array(1)))
@@ -394,9 +394,38 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldRemoveMultipleTorrents()
+    {
+        $client = $this->createMock('Transmission\Client');
+        $client->expects($this->once())
+            ->method('call')
+            ->with('torrent-remove', array('ids' => array(1, 2, 3)))
+            ->will($this->returnCallback(function () {
+                return (object) array(
+                    'result' => 'success'
+                );
+            }));
+
+        $torrent = new Torrent();
+        $torrent->setId(1);
+
+        $torrent2 = new Torrent();
+        $torrent2->setId(2);
+
+        $torrent3 = new Torrent();
+        $torrent3->setId(3);
+
+        $transmission = new Transmission();
+        $transmission->setClient($client);
+        $transmission->remove([$torrent, $torrent2, $torrent3]);
+    }
+
+    /**
+     * @test
+     */
     public function shouldRemoveDownloadWithRemovingLocalData()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('call')
             ->with('torrent-remove', array('ids' => array(1), 'delete-local-data' => true))
@@ -427,7 +456,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldProvideFacadeForClient()
     {
-        $client = $this->getMock('Transmission\Client');
+        $client = $this->createMock('Transmission\Client');
         $client->expects($this->once())
             ->method('setHost')
             ->with('example.org');


### PR DESCRIPTION
I needed to remove all torrents at once so I had to update `remove` function so here it is. Hope it will help someone too 👍 

This PR contains:

- Updated tests to work with new phpunit (`php` version 7.0^ required)
- Added phpunit as dev dependency
- Updated remove method to remove multiple torrents at once